### PR TITLE
Add TodoRepository

### DIFF
--- a/src/main/java/com/springbootprojects/todoapi/repositories/TodoRepository.java
+++ b/src/main/java/com/springbootprojects/todoapi/repositories/TodoRepository.java
@@ -1,0 +1,9 @@
+package com.springbootprojects.todoapi.repositories;
+
+import com.springbootprojects.todoapi.model.Todo;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TodoRepository extends CrudRepository<Todo, Long> {
+}


### PR DESCRIPTION
### Todo Repository
- Add Todo Repository which extends Crud Repository.
- Mark the created Todo Repository interface as a Spring Data JPA repository.